### PR TITLE
add ES6 version to have a rollup.js friendly version

### DIFF
--- a/index.es6.js
+++ b/index.es6.js
@@ -1,0 +1,26 @@
+var proto = typeof Element !== 'undefined' ? Element.prototype : {};
+var vendor = proto.matches
+  || proto.matchesSelector
+  || proto.webkitMatchesSelector
+  || proto.mozMatchesSelector
+  || proto.msMatchesSelector
+  || proto.oMatchesSelector;
+
+/**
+ * Match `el` to `selector`.
+ *
+ * @param {Element} el
+ * @param {String} selector
+ * @return {Boolean}
+ * @api public
+ */
+
+export default function match(el, selector) {
+  if (!el || el.nodeType !== 1) return false;
+  if (vendor) return vendor.call(el, selector);
+  var nodes = el.parentNode.querySelectorAll(selector);
+  for (var i = 0; i < nodes.length; i++) {
+    if (nodes[i] == el) return true;
+  }
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "matches-selector",
-  "version": "1.2.0",
+  "version": "1.3.0",
+  "main": "index.js",
+  "module": "index.es6.js",
+  "jsnext:main": "index.es6.js",
   "description": "Check if a DOM element matches a given selector, with decent browser support and unit tests.",
   "keywords": [
     "browserify",


### PR DESCRIPTION
I use rollup.js. I want to use the library 'dom-form-serializer' which uses this library. dom-form-serializer is es6 friendly for rollup.js, but the dependency 'matches-selector' is not. It also makes this library forwards compatible with es6 imports/exports.